### PR TITLE
Update main.go, add "Proxy-Authenticate" header

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Proxy-Authorization")
 		r.Header.Del("Proxy-Authorization")
 		if auth != basicAuthUserPass {
+			w.Header().Set("Proxy-Authenticate", "Basic realm=\"go-proxy\"")
 			http.Error(w, "ProxyAuthRequired", http.StatusProxyAuthRequired)
 			return
 		}


### PR DESCRIPTION
Without "Proxy-Authenticate" header, some of proxy extension like SwitchyOmega would not work when you set a userpass.
